### PR TITLE
Draft of proof bot script using ape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__
+.env
+build/
+venv/
+.python-version
+bin/
+.vscode/
+.idea/
+node_modules/
+.build
+contracts/.cache
+env
+.cache/
+dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,14 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
+  - repo: https://github.com/akaihola/darker
+    rev: 1.7.2
     hooks:
-      - id: black
+    -   id: darker
+        args: ["--check"]
+        stages: [push]
+    -   id: darker
+        stages: [commit]
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.4'
     hooks:
-      - id: flake8
-
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-      - id: isort
+    - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+      - id: isort

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ To install pre-commit locally:
 pre-commit install
 ```
 
+## Example of usage
+
+```bash
+export WEB3_INFURA_PROJECT_ID=<Infura project ID>
+export APE_ACCOUNTS_BOT_PASSPHRASE=<Passphrase for account with alias BOT>
+
+ape run proof_bot --fx-root-tunnel 0x720754c84f0b1737801bf63c950914E0C1d4aCa2 --graphql-endpoint https://api.studio.thegraph.com/query/24143/polygonchildmumbai/version/latest --proof-generator https://proof-generator.polygon.technology/api/v1/mumbai/exit-payload/ --network :goerli:infura --account BOT
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# State Transfer Bot Polygon → Ethereum
+
+Stateless bot monitors GraphQL endpoint for new events `MessageSent` that occurs on Polygon network. And then transfers proof to Ethereum root contract.
+
+## Installation
+
+We use [Ape](https://docs.apeworx.io/ape/stable/index.html) as the testing and deployment framework of this project.
+
+### Configuring Pre-commit
+
+To install pre-commit locally:
+
+```bash
+pre-commit install
+```
+

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,0 +1,14 @@
+name: train45
+contracts_folder: contracts
+
+plugins:
+  - name: solidity
+  - name: ape-etherscan
+
+solidity:
+  version: 0.8.23
+  evm_version: paris
+
+ethereum:
+  mainnet:
+    transaction_acceptance_timeout: 600  # 10 minutes

--- a/contracts/IReceiver.sol
+++ b/contracts/IReceiver.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.8.0;
+
+interface IReceiver {
+    function receiveMessage(bytes memory inputData) external;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+-i https://pypi.org/simple
+ape-infura==0.7.0
+ape-solidity==0.7.1
+ape-etherscan==0.7.1
+eth-ape==0.7.7
+eth-rlp==0.3.0 ; python_version >= '3.7' and python_version < '4'

--- a/scripts/proof_bot.py
+++ b/scripts/proof_bot.py
@@ -7,7 +7,7 @@ import requests
 import rlp
 from ape import project
 from ape.api import AccountAPI
-from ape.cli import ConnectedProviderCommand, get_user_selected_account
+from ape.cli import ConnectedProviderCommand, select_account, account_option
 from ape.contracts import ContractInstance
 from ape.exceptions import ContractLogicError
 from ape.logging import logger
@@ -102,6 +102,7 @@ def get_and_push_proof(
 
 
 @click.command(cls=ConnectedProviderCommand)
+@account_option()
 @click.option(
     "--fx-root-tunnel",
     "-fxrt",
@@ -126,8 +127,8 @@ def get_and_push_proof(
     required=True,
     type=click.STRING,
 )
-def cli(fx_root_tunnel, graphql_endpoint, proof_generator):
-    account = get_user_selected_account()
+def cli(account, fx_root_tunnel, graphql_endpoint, proof_generator):
+    account.set_autosign(enabled=True)
     receiver = project.IReceiver.at(fx_root_tunnel)
     last_blocknumber = get_polygon_last_block_number(account, receiver)
     logger.debug("Last processed block number: %d", last_blocknumber)

--- a/scripts/proof_bot.py
+++ b/scripts/proof_bot.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+
+import requests
+from ape import project
+import rlp
+from eth_typing import HexStr
+from eth_utils import to_bytes, to_int
+from ape.api import AccountAPI
+from ape.contracts import ContractInstance
+from ape.cli import get_user_selected_account
+from ape.exceptions import ContractLogicError
+
+
+def hex_to_bytes(data: str) -> bytes:
+    return to_bytes(hexstr=HexStr(data))
+
+def get_polygon_last_block_number(account: AccountAPI, fx_base_channel_root_tunnel: ContractInstance) -> int:
+
+    last_blocknumber = 0
+    for tx in account.history:
+        if tx.method_called and tx.method_called.name == 'receiveMessage':
+            last_proof_data = hex_to_bytes(tx.transaction.dict()['data'])
+            last_proof = fx_base_channel_root_tunnel.decode_input(last_proof_data)[1]['inputData']
+            decoded = rlp.decode(last_proof)
+            blocknumber = to_int(decoded[2])
+            if blocknumber > last_blocknumber:
+                last_blocknumber = blocknumber
+    
+    return last_blocknumber
+
+
+def get_message_sent_events(graphql_endpoint: str, last_blocknumber: int) -> [dict]:
+    
+    gql = """
+    query AllMessagesSent {
+    messageSents(where: {blockNumber_gte: """ + str(last_blocknumber) + """}, orderBy: blockNumber) {
+        transactionHash
+    }
+    }
+    """
+
+    s = requests.session()
+    s.headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+    }
+
+    response = s.post(graphql_endpoint, json={'query': gql})
+
+    data = response.json()
+    messages = data['data']['messageSents']
+    return messages
+
+def push_proof(account: AccountAPI, fx_base_channel_root_tunnel: ContractInstance, proof: bytes):
+    try:
+        fx_base_channel_root_tunnel.receiveMessage(proof, sender=account)
+    except ContractLogicError as e:
+        if e.message != "EXIT_ALREADY_PROCESSED":
+            raise e
+        print("processed")
+
+
+def get_and_push_proof(
+        account: AccountAPI, 
+        fx_base_channel_root_tunnel: ContractInstance, 
+        messages: [dict], 
+        event_signature: str, 
+        proof_generator: str
+        ):
+        
+    for event in messages:
+        txhash = event['transactionHash']
+        s = requests.session()
+        response = s.get(proof_generator + txhash, params={'eventSignature': event_signature})
+        if response.status_code != 200:
+            assert False, "No proof"
+        proof = response.json()['result']
+        push_proof(account, fx_base_channel_root_tunnel, proof)
+
+
+def main():  
+
+    account = get_user_selected_account()
+    polygon_root_address = "0x720754c84f0b1737801bf63c950914E0C1d4aCa2"
+
+    graphql_endpoint = "https://api.studio.thegraph.com/query/24143/polygonchildmumbai/version/latest"
+
+    event_signature = '0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036'
+    proof_generator = "https://proof-generator.polygon.technology/api/v1/mumbai/exit-payload/"
+
+    receiver = project.IReceiver.at(polygon_root_address)
+    last_blocknumber = get_polygon_last_block_number(account, receiver)
+    messages = get_message_sent_events(graphql_endpoint, last_blocknumber)
+    
+    print(messages)
+    if len(messages) == 0:
+        print("Nothing to push")
+        return
+
+    get_and_push_proof(account, receiver, messages, event_signature, proof_generator)

--- a/scripts/proof_bot.py
+++ b/scripts/proof_bot.py
@@ -47,7 +47,7 @@ def get_polygon_last_block_number(
 
 def get_message_sent_events(graphql_endpoint: str, last_blocknumber: int) -> list[dict]:
     """
-    Queries GraphQL endpoint to retreive all new `MessageSent` events
+    Queries GraphQL endpoint to retrieve all new `MessageSent` events
     on Polygon network
     """
 
@@ -84,7 +84,7 @@ def push_proof(
     except ContractLogicError as e:
         if e.message != EXIT_ALREADY_PROCESSED_ERROR:
             raise e
-        logger.info("Transaction was processed")
+        logger.info("Transaction already processed")
         return False
 
 


### PR DESCRIPTION
Transferring state between Ethereum to Polygon works automatically (Polygon network does that) but opposite direction needs some manual operations: after Polygon block is checkpointed on Ethereum - someone pushes proof to `PolygonRoot`.

So far Polygon -> Ethereum used for operator confirmations. Those txs needed on mainnet to make reward calculation correct (see TACo app).

This script is finished (working pretty well) but repo itself asks for more changes. 