### PR TITLE
Migrate subgraph queries to taco-mainnet-polygon v2.1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export WEB3_INFURA_PROJECT_ID=<Infura project ID>
 export APE_ACCOUNTS_BOT_PASSPHRASE=<Passphrase for account with alias BOT>
 export ETHERSCAN_API_KEY=<API Key for Etherscan>
 
-ape run proof_bot --fx-root-tunnel 0x51825d6e893c51836dC9C0EdF3867c57CD0cACB3--graphql-endpoint https://subgraph.satsuma-prod.com/735cd3ac7b23/nucypher-ops/PolygonChild/api --proof-generator https://proof-generator.polygon.technology/api/v1/matic/ --network ethereum:mainnet:infura --account BOT
+ape run proof_bot --fx-root-tunnel 0x51825d6e893c51836dC9C0EdF3867c57CD0cACB3 --graphql-endpoint https://api.goldsky.com/api/public/project_cmgzo6cgq00lc5np2dwaycfdl/subgraphs/taco-mainnet-polygon/v2.1.14/gn --proof-generator https://proof-generator.polygon.technology/api/v1/matic/ --network ethereum:mainnet:infura --account BOT
 ```
 
 

--- a/scripts/proof_bot.py
+++ b/scripts/proof_bot.py
@@ -56,9 +56,9 @@ def get_message_sent_events(graphql_endpoint: str, last_blocknumber: int) -> lis
     gql = (
         """
     query AllMessagesSent {
-    messageSents(where: {blockNumber_gte: """
+    bridgeMessages(where: {blockNumber_gte: """
         + str(last_blocknumber)
-        + """}, orderBy: blockNumber) {
+        + """, domain: "mainnet"}, orderBy: blockNumber) {
         blockNumber
         transactionHash
     }
@@ -72,7 +72,7 @@ def get_message_sent_events(graphql_endpoint: str, last_blocknumber: int) -> lis
     response = s.post(graphql_endpoint, json={"query": gql})
 
     data = response.json()
-    messages = data["data"]["messageSents"]
+    messages = data["data"]["bridgeMessages"]
     return messages
 
 

--- a/scripts/resender.py
+++ b/scripts/resender.py
@@ -11,21 +11,28 @@ from ape.logging import logger
 
 def get_release_events(graphql_endpoint: str) -> list[dict]:
     """
-    Queries GraphQL endpoint to retrieve all new `Release` events
-    on Polygon network
+    Queries GraphQL endpoint to retrieve stakers with a `CHILD_RELEASED`
+    event that has no subsequent `CHILD_RELEASE_RESENT`.
     """
 
-    gql = (
-        """
+    gql = """
     query ReleasetoResend {
-    releaseds(
-        where: {releaseTxSender: "0x0000000000000000000000000000000000000000", releaseResent: false}
+        released: authorizationEvents(
+            where: {eventType: CHILD_RELEASED}
+            first: 1000
         ) {
-            id
+            stakingProvider { id }
+            blockNumber
+        }
+        resent: authorizationEvents(
+            where: {eventType: CHILD_RELEASE_RESENT}
+            first: 1000
+        ) {
+            stakingProvider { id }
+            blockNumber
         }
     }
     """
-    )
 
     s = requests.session()
     s.headers = {"Accept": "application/json", "Content-Type": "application/json"}
@@ -34,9 +41,28 @@ def get_release_events(graphql_endpoint: str) -> list[dict]:
     if response.status_code != 200:
         raise Exception(f"GraphQL endpoint not reachable [Error {response.status_code} - {response.text}]")
 
-    data = response.json()
-    messages = data["data"]["releaseds"]
-    return messages
+    data = response.json()["data"]
+
+    latest_resent: dict[str, int] = {}
+    for event in data["resent"]:
+        staker = event["stakingProvider"]["id"]
+        block = int(event["blockNumber"])
+        if block > latest_resent.get(staker, -1):
+            latest_resent[staker] = block
+
+    latest_released: dict[str, int] = {}
+    for event in data["released"]:
+        staker = event["stakingProvider"]["id"]
+        block = int(event["blockNumber"])
+        if block > latest_released.get(staker, -1):
+            latest_released[staker] = block
+
+    pending = [
+        {"id": staker}
+        for staker, released_block in latest_released.items()
+        if released_block > latest_resent.get(staker, -1)
+    ]
+    return pending
 
 
 def resend_tx(


### PR DESCRIPTION
## Summary

- The PolygonChild subgraph on satsuma is gone; this points both bots at the new Goldsky-hosted `taco-mainnet-polygon` v2.1.14 subgraph and updates the queries for its (significantly different) schema.
- `scripts/proof_bot.py`: `messageSents` → `bridgeMessages` (with `domain: "mainnet"` filter).
- `scripts/resender.py`: `Released` / `releaseResent` are gone. Replaced by dual-query over `authorizationEvents` filtering `CHILD_RELEASED` and `CHILD_RELEASE_RESENT`, with client-side set-diff comparing latest block per staker.

## Notes

- Deployed `.env` must be updated: `GQL_URL=https://api.goldsky.com/api/public/project_cmgzo6cgq00lc5np2dwaycfdl/subgraphs/taco-mainnet-polygon/v2.1.14/gn`
- Against live data, the resender currently identifies **17 stakers pending resend** — this likely reflects backlog accumulated while the endpoint was stale. `scripts/resender.py:47` has no error handling, so any reverting `resendRelease` will abort the batch.

## Test plan

- [x] `bridgeMessages` query verified against the new endpoint (returns expected block/txhash pairs)
- [x] Resender dual-query verified end-to-end: 35 `CHILD_RELEASED` + 19 `CHILD_RELEASE_RESENT` events, 17 pending resends (known-resent stakers correctly excluded, e.g. `0xc4f03e31...`)
- [ ] Run `ape run proof_bot` against the new endpoint in a staging account
- [ ] Run `ape run resender` against the new endpoint in a staging account (mind the 17-staker backlog)
- [ ] Update `GQL_URL` in the deployed `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)